### PR TITLE
Replace Http to Https due to Insecure HTTP Request

### DIFF
--- a/lib/coingecko_dart.dart
+++ b/lib/coingecko_dart.dart
@@ -57,7 +57,7 @@ class CoinGeckoApi {
       bool? rateLimitManagement = true,
       bool enableLogging = true}) {
     var options = BaseOptions(
-        baseUrl: 'http://api.coingecko.com/api/v3',
+        baseUrl: 'https://api.coingecko.com/api/v3',
         connectTimeout: connectTimeout,
         receiveTimeout: receiveTimeout,
         validateStatus: (code) => true,


### PR DESCRIPTION
Small change to fix an issue with insecure HTTP request:

```log
[VERBOSE-2:ui_dart_state.cc(186)] Unhandled Exception: DioError [DioErrorType.other]: Bad state: Insecure HTTP is not allowed by platform: http://api.coingecko.com/api/v3/simple/price?ids=dogecoin&vs_currencies=EUR&include_market_cap=false&include_24hr_vol=false&include_24hr_change=false&include_last_updated_at=false
```

More details here: https://flutter.dev/docs/release/breaking-changes/network-policy-ios-android

