### PR TITLE
fixed Coin.fromJson, implemented OHLC API Call

### DIFF
--- a/lib/coingecko_dart.dart
+++ b/lib/coingecko_dart.dart
@@ -178,6 +178,28 @@ class CoinGeckoApi {
     }
   }
 
+  // ? /coins/{id}/ohlc
+  Future<CoinGeckoResult<dynamic>> ohlc(
+      {required String id,
+        required List<String> vs_currencies,
+        required int days,}) async {
+
+    Response response =
+    await dio!.get('/coins/$id/ohlc', queryParameters: {
+      "vs_currency": vs_currencies.join(','),
+      "days": days,
+    });
+
+    if (response.statusCode == 200) {
+      return CoinGeckoResult<dynamic>(response.data);
+    } else {
+      return CoinGeckoResult([],
+          errorMessage: "failed with code ${response.statusCode}",
+          errorCode: response.statusCode ?? -1,
+          isError: true);
+    }
+  }
+
   // ? /simple/supported_vs_currencies
   Future<CoinGeckoResult<List<String>>> simpleSupportedVsCurrencies() async {
     Response response = await dio!.get('/simple/supported_vs_currencies',

--- a/lib/dataClasses/coins/Coin.dart
+++ b/lib/dataClasses/coins/Coin.dart
@@ -15,8 +15,8 @@ class Coin {
     return "ID: $id, SYMBOL: $symbol, NAME: $name";
   }
 
-  Coin.fromJson(Map<String, dynamic> json) {
-    json = json;
+  Coin.fromJson(Map<String, dynamic> jsonData) {
+    json = Map<String, dynamic>.from(jsonData);
     id = json['id'];
     symbol = json['symbol'];
     name = json['name'];


### PR DESCRIPTION
The method Coin.fromJson currently does not populate the 'json' property. This PR fixes it.